### PR TITLE
Fix async keyword usage in training module

### DIFF
--- a/cresi/net/pytorch_utils/train.py
+++ b/cresi/net/pytorch_utils/train.py
@@ -191,8 +191,12 @@ class Estimator:
 
         meter = defaultdict(float)
         for input, target in zip(inputs, targets):
-            input = torch.autograd.Variable(input.cuda(async=True), volatile=not training)
-            target = torch.autograd.Variable(target.cuda(async=True), volatile=not training)
+            input = torch.autograd.Variable(
+                input.cuda(non_blocking=True), volatile=not training
+            )
+            target = torch.autograd.Variable(
+                target.cuda(non_blocking=True), volatile=not training
+            )
             if verbose:
                 print("input.shape, target.shape:", input.shape, target.shape)
             output = self.model(input)


### PR DESCRIPTION
## Summary
- fix SyntaxError in train loop by replacing `async` with `non_blocking`

## Testing
- `python -m py_compile cresi/net/pytorch_utils/train.py && echo "compiled"`


------
https://chatgpt.com/codex/tasks/task_e_687359c80a888331b3f6e66a554f66fe