### PR TITLE
Add build essentials for pip installs

### DIFF
--- a/docker/cpu/Dockerfile
+++ b/docker/cpu/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /opt/cresi
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        python3 python3-pip git wget unzip libgl1 libgdal-dev gdal-bin && \
+        python3 python3-pip git wget unzip libgl1 libgdal-dev gdal-bin build-essential python3-dev && \
     rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt /tmp/requirements.txt

--- a/docker/mps/Dockerfile
+++ b/docker/mps/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /opt/cresi
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        python3 python3-pip git wget unzip libgl1 libgdal-dev gdal-bin && \
+        python3 python3-pip git wget unzip libgl1 libgdal-dev gdal-bin build-essential python3-dev && \
     rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt /tmp/requirements.txt


### PR DESCRIPTION
## Summary
- add `build-essential` and `python3-dev` to CPU and MPS Dockerfiles

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68738e060d3c833199e827c96628b108